### PR TITLE
Fix example in readme for newest Rust nightly

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ mod test {
 
 Run tests:
 
-```rust
+```
 $ cargo test
    Compiling air v0.1.0 (file:///Users/kriomant/Temp/air)
      Running target/debug/air-b2c5f8b6920cb30a

--- a/README.md
+++ b/README.md
@@ -83,19 +83,19 @@ mod test {
   #[test]
   fn test_set_temperature_20() {
       let mut scenario = Scenario::new();
-      let cond = scenario.create_mock_for::<AirConditioner>();
+      let mut cond = scenario.create_mock_for::<AirConditioner>();
 
       scenario.expect(cond.get_temperature_call().and_return(16));
       scenario.expect(cond.make_hotter_call(4).and_return(()));
 
-      set_temperature_20(&cond);
+      set_temperature_20(&mut cond);
   }
 }
 ```
 
 Run tests:
 
-```
+```rust
 $ cargo test
    Compiling air v0.1.0 (file:///Users/kriomant/Temp/air)
      Running target/debug/air-b2c5f8b6920cb30a


### PR DESCRIPTION
* `cont` must be mutable to run the example code
* Add syntax highlighting for Rust test output