### PR TITLE
Don't use feature(alloc)

### DIFF
--- a/mockers/src/lib.rs
+++ b/mockers/src/lib.rs
@@ -1,6 +1,4 @@
-#![feature(fnbox, alloc, specialization)]
-
-extern crate alloc;
+#![feature(fnbox, specialization)]
 
 use std::marker::PhantomData;
 use std::rc::{Rc, Weak};

--- a/mockers/src/matchers/mod.rs
+++ b/mockers/src/matchers/mod.rs
@@ -4,9 +4,9 @@ use std::marker::PhantomData;
 use std::fmt::Debug;
 
 use std;
+use std::fmt::Write;
 use std::ops::RangeBounds;
 use std::collections::Bound;
-use alloc::fmt::Write;
 
 pub use self::ext::*;
 pub use self::option::*;


### PR DESCRIPTION
I'm not sure why it was originally needed, but as of rustc
1.31.0-nightly (de9666f12 2018-10-31) it's no longer necessary.