### PR TITLE
Fix import path

### DIFF
--- a/mockers/src/lib.rs
+++ b/mockers/src/lib.rs
@@ -18,7 +18,7 @@ pub mod matchers;
 pub mod clone;
 pub mod type_info;
 
-pub use type_info::TypeInfo;
+pub use crate::type_info::TypeInfo;
 
 use crate::cardinality::{Cardinality, CardinalityCheckResult};
 use crate::dbg::dbg;


### PR DESCRIPTION
The build will succeed if it is the latest version of rustc, but in a little earlier version you get an error .

example: rustc 1.33.0-nightly (c2d381d39 2019-01-10)
```
imports can only refer to extern crate names passed with' - extern 'on stable channel (see issue # 53130)' .
```